### PR TITLE
Remove every unnecessary TestPropertySource annotation

### DIFF
--- a/auth/src/test/java/ml/echelon133/microblog/auth/service/CustomOAuth2AuthorizationServiceTests.java
+++ b/auth/src/test/java/ml/echelon133/microblog/auth/service/CustomOAuth2AuthorizationServiceTests.java
@@ -28,12 +28,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-/*
-    Disable kubernetes during tests to make local execution of tests possible.
-    If kubernetes is not disabled, tests won't execute at all because Spring will
-    fail to configure kubernetes when run outside it.
- */
-@TestPropertySource(properties = "spring.cloud.kubernetes.enabled=false")
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Tests of CustomOAuth2AuthorizationService")
 public class CustomOAuth2AuthorizationServiceTests {

--- a/post/src/test/java/ml/echelon133/microblog/post/controller/PostControllerTests.java
+++ b/post/src/test/java/ml/echelon133/microblog/post/controller/PostControllerTests.java
@@ -40,12 +40,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static ml.echelon133.microblog.shared.auth.test.OAuth2RequestPostProcessor.*;
 import static ml.echelon133.microblog.shared.auth.test.TestOpaqueTokenData.*;
 
-/*
-    Disable kubernetes during tests to make local execution of tests possible.
-    If kubernetes is not disabled, tests won't execute at all because Spring will
-    fail to configure kubernetes when run outside it.
- */
-@TestPropertySource(properties = "spring.cloud.kubernetes.enabled=false")
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Tests of PostController")
 public class PostControllerTests {

--- a/post/src/test/java/ml/echelon133/microblog/post/service/PostServiceTests.java
+++ b/post/src/test/java/ml/echelon133/microblog/post/service/PostServiceTests.java
@@ -29,12 +29,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-/*
-    Disable kubernetes during tests to make local execution of tests possible.
-    If kubernetes is not disabled, tests won't execute at all because Spring will
-    fail to configure kubernetes when run outside it.
- */
-@TestPropertySource(properties = "spring.cloud.kubernetes.enabled=false")
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Tests of PostService")
 public class PostServiceTests {

--- a/post/src/test/java/ml/echelon133/microblog/post/service/TagServiceTests.java
+++ b/post/src/test/java/ml/echelon133/microblog/post/service/TagServiceTests.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 import java.util.Optional;
@@ -17,12 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
-/*
-    Disable kubernetes during tests to make local execution of tests possible.
-    If kubernetes is not disabled, tests won't execute at all because Spring will
-    fail to configure kubernetes when run outside it.
- */
-@TestPropertySource(properties = "spring.cloud.kubernetes.enabled=false")
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Tests of TagService")
 public class TagServiceTests {

--- a/user/src/test/java/ml/echelon133/microblog/user/controller/UserControllerTests.java
+++ b/user/src/test/java/ml/echelon133/microblog/user/controller/UserControllerTests.java
@@ -43,12 +43,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static ml.echelon133.microblog.shared.auth.test.OAuth2RequestPostProcessor.*;
 import static ml.echelon133.microblog.shared.auth.test.TestOpaqueTokenData.*;
 
-/*
-    Disable kubernetes during tests to make local execution of tests possible.
-    If kubernetes is not disabled, tests won't execute at all because Spring will
-    fail to configure kubernetes when run outside it.
- */
-@TestPropertySource(properties = "spring.cloud.kubernetes.enabled=false")
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Tests of UserController")
 public class UserControllerTests {

--- a/user/src/test/java/ml/echelon133/microblog/user/service/UserServiceTests.java
+++ b/user/src/test/java/ml/echelon133/microblog/user/service/UserServiceTests.java
@@ -30,12 +30,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-/*
-    Disable kubernetes during tests to make local execution of tests possible.
-    If kubernetes is not disabled, tests won't execute at all because Spring will
-    fail to configure kubernetes when run outside it.
- */
-@TestPropertySource(properties = "spring.cloud.kubernetes.enabled=false")
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Tests of UserService")
 public class UserServiceTests {


### PR DESCRIPTION
Test classes which use Mockito do not require disabling kubernetes during testing because they do not even attempt to configure it. All unnecessary annotations which disable k8s have been removed.